### PR TITLE
Add light and dark mode toggle

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,3 +13,4 @@
     </p>
   </div>
 </footer>
+<script src="{{ '/js/theme-toggle.js' | relative_url }}"></script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,5 +16,10 @@
         {% endif %}
       {% endfor %}
     </div>
+    <div class="navbar-end">
+      <div class="navbar-item">
+        <button id="theme-toggle" class="button is-white is-small">🌓</button>
+      </div>
+    </div>
   </div>
 </nav>

--- a/_sass/_dark-theme.scss
+++ b/_sass/_dark-theme.scss
@@ -1,0 +1,33 @@
+/* Dark mode styles */
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #1a1a1a;
+    color: #f5f5f5;
+  }
+  a {
+    color: lighten($brand-color, 25%);
+  }
+  .navbar {
+    background-color: #242424;
+  }
+  .footer {
+    background-color: #242424;
+    color: #f5f5f5;
+  }
+}
+
+body.dark-mode {
+  background-color: #1a1a1a;
+  color: #f5f5f5;
+}
+body.dark-mode a {
+  color: lighten($brand-color, 25%);
+}
+body.dark-mode .navbar {
+  background-color: #242424;
+}
+body.dark-mode .footer {
+  background-color: #242424;
+  color: #f5f5f5;
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -49,4 +49,5 @@ $on-laptop:        800px;
         "base",
         "layout",
         "syntax-highlighting"
+        , "dark-theme"
 ;

--- a/js/theme-toggle.js
+++ b/js/theme-toggle.js
@@ -1,0 +1,34 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var storageKey = 'theme';
+  var classNameDark = 'dark-mode';
+  var toggleButton = document.getElementById('theme-toggle');
+  if (!toggleButton) return;
+  var navbar = document.querySelector('nav.navbar');
+
+  function setClass(dark) {
+    if (dark) {
+      document.body.classList.add(classNameDark);
+      if (navbar) {
+        navbar.classList.remove('is-light');
+        navbar.classList.add('is-dark');
+      }
+    } else {
+      document.body.classList.remove(classNameDark);
+      if (navbar) {
+        navbar.classList.remove('is-dark');
+        navbar.classList.add('is-light');
+      }
+    }
+  }
+
+  var stored = localStorage.getItem(storageKey);
+  var prefers = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  var darkMode = stored ? stored === 'dark' : prefers;
+  setClass(darkMode);
+
+  toggleButton.addEventListener('click', function () {
+    darkMode = !darkMode;
+    localStorage.setItem(storageKey, darkMode ? 'dark' : 'light');
+    setClass(darkMode);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dark theme stylesheet with basic colors
- include a theme toggle button in the navbar
- implement theme toggle logic with localStorage
- load toggle script from the footer

## Testing
- `jekyll --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860a5d28dc08326bada426166e56cbe